### PR TITLE
Add temporary fix for Dokka CI failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,4 +22,8 @@ jobs:
       - run: ./gradlew assemble
       - run: ./gradlew assemble -Dquarkus.native.enabled=true -Dquarkus.package.jar.enabled=false
       - run: ./gradlew test
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          distribution: graalvm-community
+          java-version: 24
       - run: ./gradlew dokkaGeneratePublicationHtml


### PR DESCRIPTION
Dokka and/or Kotlin don't yet fully support Java 25, causing our Dokka task to fail when running under Java 25. As a temporary fix until Java 25 is supported by Kotlin and Dokka, switch our Java version in CI from Java 25 to 24 for only the Dokka task.